### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a fork of [EdytorNC](https://github.com/artur3/EdytorNC), a text editor
 for CNC programmers.
 
 - [Some features](#some-features)
-- [Some shotcuts](#some-shotcuts)
+- [Some shortcuts](#some-shortcuts)
 - [Getting GCodeWorkShop](#getting-gcodeworkshop)
 - [Command line options](#command-line-options)
 
@@ -37,7 +37,7 @@ Some features
 * Solutions of triangles calculation
 
 
-Some shotcuts
+Some shortcuts
 ------------
 
 * `Ctrl+;` Comments/uncomments selected text with semicolon ;
@@ -49,7 +49,7 @@ Some shotcuts
   operations directly in editor. You can select address (eg `X123.45`) before
   pressing `Ctrl+0` (`Ctrl+Double Click` will do the same), value will be
   entered in the calc.  
-  After presing `Enter` (and if no error) result will be pasted in cursor
+  After pressing `Enter` (and if no error) result will be pasted in cursor
   position. Supported operators: `+` `-` `*` `/` `SIN(x)` `COS(x)` `TAN(x)`
   `SQRT(x)` `SQR(x)` `ABS(x)` `TRUNC(x)` `PI`
 

--- a/addons/src/bhc/bhcdialog.cpp
+++ b/addons/src/bhc/bhcdialog.cpp
@@ -429,7 +429,7 @@ void BHCDialog::computeButtonClicked()
 		drawing->printText(textPosX, textPosY, 2 - dir,
 		                   QString(tr("Angle of first hole : %1")).arg(firstAngle), col);
 		drawing->printText(textPosX, textPosY, 3 - dir,
-		                   QString(tr("Angle beetwen holes : %1")).arg(angleBeetwen), col);
+		                   QString(tr("Angle between holes : %1")).arg(angleBeetwen), col);
 		drawing->printText(textPosX, textPosY, 4 - dir,
 		                   QString(tr("Center position : X%1 Y%2")).arg(xCenter).arg(yCenter), col);
 		firstAngle += roate;

--- a/addons/src/bhc/bhctab.ui
+++ b/addons/src/bhc/bhctab.ui
@@ -145,7 +145,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Angle beetwen holes :</string>
+           <string>Angle between holes :</string>
           </property>
           <property name="buddy">
            <cstring>angleBeetwenInput</cstring>

--- a/addons/src/compilemacro/utils-compilemacro.cpp
+++ b/addons/src/compilemacro/utils-compilemacro.cpp
@@ -194,7 +194,7 @@ void Utils::CompileMacro::setError(int error, const QString& tx)
 			break;
 
 		case ERR_DOUBLE_DOT:
-			m_status = tr("Decimal point or minus writed two times !\n\"%1\"").arg(tx);
+			m_status = tr("Decimal point or minus written two times !\n\"%1\"").arg(tx);
 			break;
 
 		default:

--- a/addons/src/renumber/renumberdialog.ui
+++ b/addons/src/renumber/renumberdialog.ui
@@ -213,7 +213,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Just write N at begining of line and use this function to replace N with correct line number</string>
+         <string>Just write N at beginning of line and use this function to replace N with correct line number</string>
         </property>
         <property name="text">
          <string>Renumber lines marked 'N'</string>

--- a/common.pri
+++ b/common.pri
@@ -7,7 +7,7 @@ CONFIG(debug, debug|release) {
     CONFIG *= warn_on
 } else {
     BUILD_FLAG = release
-    # Supress debug message
+    # Suppress debug message
     DEFINES *= QT_NO_DEBUG_OUTPUT # QT_NO_INFO_OUTPUT
 }
 

--- a/gcodefileserver/gcodefileserver.cpp
+++ b/gcodefileserver/gcodefileserver.cpp
@@ -100,7 +100,7 @@ GCodeFileServer::~GCodeFileServer()
 void GCodeFileServer::closeEvent(QCloseEvent* event)
 {
 	//    QMessageBox::StandardButton result = QMessageBox::warning(this, tr("GCodeWorkShop - Serial port file server"),
-	//                                                              tr("You are trying to close a file server.\nAre you shure?"),
+	//                                                              tr("You are trying to close a file server.\nAre you sure?"),
 	//                                                              QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
 
 	//    if(result == QMessageBox::No)

--- a/gcodeshared/include/utils/configpage.h
+++ b/gcodeshared/include/utils/configpage.h
@@ -113,14 +113,14 @@ public slots:
 	/**
 	 * @brief Actions when confirm the changes made.
 	 *
-	 * This is happend by pressing the "OK" button.
+	 * This occurs when pressing the "OK" button.
 	 */
 	virtual void accept() {}
 
 	/**
 	 * @brief Actions when rejecting the changes made.
 	 *
-	 * This is happend by pressing the "Cancel" button. If you have @link start() backup@endlink
+	 * This occurs when pressing the "Cancel" button. If you have @link start() backup@endlink
 	 * your settings, it's time to apply them.
 	 */
 	virtual void reject() {}
@@ -128,7 +128,7 @@ public slots:
 	/**
 	 * @brief Actions when requesting default settings.
 	 *
-	 * This is happend by pressing the "Default" button. If you implement this feature,
+	 * This occurs when pressing the "Default" button. If you implement this feature,
 	 * override the hasReset() function so that it returns @c true.
 	 */
 	virtual void reset() {}

--- a/gcodeshared/serialportconfigdialog.ui
+++ b/gcodeshared/serialportconfigdialog.ui
@@ -647,7 +647,7 @@ Set XON or XOFF to 0 if you want disable it.</string>
           <widget class="QSpinBox" name="autoCloseSpinBox">
            <property name="toolTip">
             <string>Automatically close transmission dialog after the last character was sent/received.
-This setting is also used in file server mode to detect end of incoming transmission and gives time to operator to swich CNC into reciving mode.</string>
+This setting is also used in file server mode to detect end of incoming transmission and gives time to operator to switch CNC into receiving mode.</string>
            </property>
            <property name="suffix">
             <string>s</string>
@@ -742,7 +742,7 @@ Works only when receiving file.</string>
        <item>
         <widget class="QCheckBox" name="deleteControlChars">
          <property name="toolTip">
-          <string>Delete all control chracters (&lt;0x3F; &gt;0x7F) from recieved file</string>
+          <string>Delete all control characters (&lt;0x3F; &gt;0x7F) from received file</string>
          </property>
          <property name="text">
           <string>Delete control chars</string>
@@ -775,7 +775,7 @@ Works only when receiving file.</string>
           <widget class="QLineEdit" name="removeLineEdit">
            <property name="toolTip">
             <string>Use this to remove some unwanted characters from received data.
-Vailid QtRegExp should be entered.</string>
+Valid QtRegExp should be entered.</string>
            </property>
            <property name="maxLength">
             <number>128</number>
@@ -944,7 +944,7 @@ Vailid QtRegExp should be entered.</string>
          <item row="2" column="2">
           <widget class="QLineEdit" name="eotInput">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These characters will be added at the end of the program.&lt;/p&gt;&lt;p&gt;You can write here:&lt;/p&gt;&lt;p&gt;	Plain text&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Hex codes of ASCII characters.&lt;/p&gt;&lt;p&gt;	Example: &lt;/p&gt;&lt;p&gt;	% 0x0A 0x0D - % and new line characters&lt;/p&gt;&lt;p&gt;	0x20 0x0A 0x0D - space character and new line characters&lt;/p&gt;&lt;p&gt;	Space and control characters can only be written as hex numbers:&lt;/p&gt;&lt;p&gt;	0x20 (space), 0x13 (XOFF), 0x11 (XON) ...&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Special characters codes can be used:&lt;/p&gt;&lt;p&gt;	LF - Line Feed also Carrige Return (replaced later by end of block characters)&lt;/p&gt;&lt;p&gt;	SP - Space&lt;/p&gt;&lt;p&gt;	TAB - Tabulation&lt;/p&gt;&lt;p&gt;	FN - File name&lt;/p&gt;&lt;p&gt;	FE - File name Extension (part after dot)&lt;/p&gt;&lt;p&gt;	FA - File name extension Appended at end of file name (part after _ character and before dot)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These characters will be added at the end of the program.&lt;/p&gt;&lt;p&gt;You can write here:&lt;/p&gt;&lt;p&gt;	Plain text&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Hex codes of ASCII characters.&lt;/p&gt;&lt;p&gt;	Example: &lt;/p&gt;&lt;p&gt;	% 0x0A 0x0D - % and new line characters&lt;/p&gt;&lt;p&gt;	0x20 0x0A 0x0D - space character and new line characters&lt;/p&gt;&lt;p&gt;	Space and control characters can only be written as hex numbers:&lt;/p&gt;&lt;p&gt;	0x20 (space), 0x13 (XOFF), 0x11 (XON) ...&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Special characters codes can be used:&lt;/p&gt;&lt;p&gt;	LF - Line Feed also Carriage Return (replaced later by end of block characters)&lt;/p&gt;&lt;p&gt;	SP - Space&lt;/p&gt;&lt;p&gt;	TAB - Tabulation&lt;/p&gt;&lt;p&gt;	FN - File name&lt;/p&gt;&lt;p&gt;	FE - File name Extension (part after dot)&lt;/p&gt;&lt;p&gt;	FA - File name extension Appended at end of file name (part after _ character and before dot)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maxLength">
             <number>128</number>
@@ -963,7 +963,7 @@ Vailid QtRegExp should be entered.</string>
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These characters will be added at the beginning of the program. &lt;/p&gt;&lt;p&gt;You can write here:&lt;/p&gt;&lt;p&gt;	Plain text&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Hex codes of ASCII characters.&lt;/p&gt;&lt;p&gt;	Example: &lt;/p&gt;&lt;p&gt;	% 0x0A 0x0D - % and new line characters&lt;/p&gt;&lt;p&gt;	0x20 0x0A 0x0D - space character and new line characters&lt;/p&gt;&lt;p&gt;	Space and control characters can only be written as hex numbers:&lt;/p&gt;&lt;p&gt;	0x20 (space), 0x13 (XOFF), 0x11 (XON) ...&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Special characters codes can be used:&lt;/p&gt;&lt;p&gt;	LF - Line Feed also Carrige Return (replaced later by end of block characters)&lt;/p&gt;&lt;p&gt;	SP - Space&lt;/p&gt;&lt;p&gt;	TAB - Tabulation&lt;/p&gt;&lt;p&gt;	FN - File name&lt;/p&gt;&lt;p&gt;	FE - File name Extension (part after dot)&lt;/p&gt;&lt;p&gt;	FA - File name extension Appended at end of file name (part after _ character and before dot)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These characters will be added at the beginning of the program. &lt;/p&gt;&lt;p&gt;You can write here:&lt;/p&gt;&lt;p&gt;	Plain text&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Hex codes of ASCII characters.&lt;/p&gt;&lt;p&gt;	Example: &lt;/p&gt;&lt;p&gt;	% 0x0A 0x0D - % and new line characters&lt;/p&gt;&lt;p&gt;	0x20 0x0A 0x0D - space character and new line characters&lt;/p&gt;&lt;p&gt;	Space and control characters can only be written as hex numbers:&lt;/p&gt;&lt;p&gt;	0x20 (space), 0x13 (XOFF), 0x11 (XON) ...&lt;/p&gt;&lt;p&gt;AND/OR&lt;/p&gt;&lt;p&gt;	Special characters codes can be used:&lt;/p&gt;&lt;p&gt;	LF - Line Feed also Carriage Return (replaced later by end of block characters)&lt;/p&gt;&lt;p&gt;	SP - Space&lt;/p&gt;&lt;p&gt;	TAB - Tabulation&lt;/p&gt;&lt;p&gt;	FN - File name&lt;/p&gt;&lt;p&gt;	FE - File name Extension (part after dot)&lt;/p&gt;&lt;p&gt;	FA - File name extension Appended at end of file name (part after _ character and before dot)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maxLength">
             <number>128</number>
@@ -1012,7 +1012,7 @@ Vailid QtRegExp should be entered.</string>
          <item row="3" column="2">
           <widget class="QComboBox" name="eobComboBox">
            <property name="toolTip">
-            <string>Line (block) endings charcters.
+            <string>Line (block) endings characters.
 Only uppercase LF, CR character are allowed.</string>
            </property>
            <property name="editable">
@@ -1172,7 +1172,7 @@ Only uppercase LF, CR character are allowed.</string>
              <widget class="QSpinBox" name="startDelaySpinBox">
               <property name="toolTip">
                <string>If 0 then waits for XON, if &gt;0 waits for timeout or XON, which one first.
-This setting works also with hardware flow control, put 0 to XON or XOFF characters to start trasmission without waiting for XON.
+This setting works also with hardware flow control, put 0 to XON or XOFF characters to start transmission without waiting for XON.
 This setting is ignored in serial File Server.</string>
               </property>
               <property name="suffix">
@@ -1303,7 +1303,7 @@ If the file name has not been automatically detected, the file name will be the 
           <item row="0" column="0">
            <widget class="QCheckBox" name="detectFormFileNameCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, filename of program to save will be taken from program name eg O0051, :1246, %MPF456, %_N_PR25475002_MPF, $O0004.MIN%... &lt;/p&gt;&lt;p&gt;If filename will be empty (not found) user definied regular expression will be used. If not found date-time code will be uased as filename. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If checked, user definied regular expression will be used first, if not found name of program will be used and if not found date-code.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, filename of program to save will be taken from program name eg O0051, :1246, %MPF456, %_N_PR25475002_MPF, $O0004.MIN%... &lt;/p&gt;&lt;p&gt;If filename will be empty (not found) user defined regular expression will be used. If not found date-time code will be uased as filename. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If checked, user defined regular expression will be used first, if not found name of program will be used and if not found date-code.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Built-in name detection</string>

--- a/gcodeshared/serialporttestdialog.cpp
+++ b/gcodeshared/serialporttestdialog.cpp
@@ -320,7 +320,7 @@ void SerialPortTestDialog::updateLeds()
 			}
 
 			count++;
-			errorLabel->setText(tr("Recived: %1 bytes.").arg(count));
+			errorLabel->setText(tr("Received: %1 bytes.").arg(count));
 			tx = ch;
 
 			qApp->processEvents();
@@ -430,7 +430,7 @@ void SerialPortTestDialog::showError(int error)
 {
 	switch (error) {
 	case QSerialPort::NoError:
-		errorLabel->setText("No Error has occured");
+		errorLabel->setText("No Error has occurred");
 		break;
 
 	case QSerialPort::DeviceNotFoundError:

--- a/gcodeshared/serialtransmissiondialog.cpp
+++ b/gcodeshared/serialtransmissiondialog.cpp
@@ -295,7 +295,7 @@ void SerialTransmissionDialog::updateStatus()
 					}
 				}
 			} else {
-				if (writeBufferIterator != serialPortWriteBuffer.end()) { // try to restart trasmission
+				if (writeBufferIterator != serialPortWriteBuffer.end()) { // try to restart transmission
 					serialPortBytesWritten(0);
 				}
 
@@ -351,7 +351,7 @@ void SerialTransmissionDialog::showSerialPortError(QSerialPort::SerialPortError 
 
 	switch (error) {
 	case QSerialPort::NoError:
-		text = tr("No Error has occured");
+		text = tr("No Error has occurred");
 		//statusBar()->showMessage(text);
 		return;
 
@@ -457,7 +457,7 @@ void SerialTransmissionDialog::serialPortBytesWritten(qint64 bytes)
 			sendTimeoutCountner = 0;
 			sendTimeoutTimer->stop();
 			setLabelText(tr("OK:\t Sending completed."), serverMode, true);
-			setLabelText(tr("Wainting for data..."));
+			setLabelText(tr("Waiting for data..."));
 			setRange(0, 0);
 		} else {
 			autoCloseCountner = portSettings.autoCloseTimeout;
@@ -530,7 +530,7 @@ void SerialTransmissionDialog::serialPortBytesWritten(qint64 bytes)
 //        if(QString(buff).contains(endOfProgChar) && (!endOfProgChar.isEmpty()))
 //        {
 //            qDebug() << "endOfProgChar" << endOfProgChar;
-//            qDebug() << "Procces data" << processReceivedData();
+//            qDebug() << "Process data" << processReceivedData();
 //        }
 
 //    }
@@ -695,7 +695,7 @@ void SerialTransmissionDialog::prepareDataBeforeSending(QString* data)
 	auto behavior = Qt::SkipEmptyParts;
 #endif
 	serialPortWriteBuffer = data->split("\n", behavior);
-	// insert line endings. \r is replaced with choosen line ending
+	// insert line endings. \r is replaced with chosen line ending
 	serialPortWriteBuffer.replaceInStrings("\r", portSettings.eobChar);
 
 	noOfBytes = serialPortWriteBuffer.join("").length();  // get new size
@@ -1116,7 +1116,7 @@ QStringList SerialTransmissionDialog::guessFileName(QString* text)
 }
 
 //**************************************************************************************************
-//  Save received program to a file. Return filename and empty program text if succes or leave program text unchanged
+//  Save received program to a file. Return filename and empty program text if successful or leave program text unchanged
 //**************************************************************************************************
 
 QString SerialTransmissionDialog::saveDataToFile(QString* text)
@@ -1474,7 +1474,7 @@ void SerialTransmissionDialog::fileServerBytesWritten(qint64 bytes)
 void SerialTransmissionDialog::sendTimeoutTimerTimeout()
 {
 	if (sendTimeoutCountner == 0) {
-		setLabelText(tr("ERROR:\t Sending timedout. Reseting."), serverMode, true);
+		setLabelText(tr("ERROR:\t Sending timedout. Resetting."), serverMode, true);
 		sendTimeoutTimer->stop();
 		reset(false);
 		return;

--- a/gcodeshared/utils/medium.cpp
+++ b/gcodeshared/utils/medium.cpp
@@ -64,10 +64,10 @@ Medium::Medium(QObject* parent) :
 	setupDirs();
 	mShareDirs.append(COLON);
 
-	qDebug() << "Seting directoryes:";
+	qDebug() << "Setting directories:";
 	qDebug() << "  translation   " << mTranslationDirs;
 	qDebug() << "  config        " << mSettingsDir;
-	qDebug() << "  programm data " << mShareDirs;
+	qDebug() << "  program data  " << mShareDirs;
 
 	QString settingFile = mSettingsDir;
 	settingFile.append(SLASH).append(APP_NAME).append(".ini");

--- a/gcodeworkshop/include/document.h
+++ b/gcodeworkshop/include/document.h
@@ -40,8 +40,8 @@ class QWidget;
  *
  * The derived class must have a unique type returned by type(). The value returned by
  * brief() is used in a widget with a list of open documents. The guessFileName() function
- * is called when an unitled document is saved to guess a possible file name. Whether the
- * document is unitled can be checked using the isUntitled() function.
+ * is called when an untitled document is saved to guess a possible file name. Whether the
+ * document is untitled can be checked using the isUntitled() function.
  *
  * The class has an associated widget, accessible using widget() function. The descendants
  * must call setWidget() in the constructor to associate the widget with the document.

--- a/gcodeworkshop/src/documentmanager.cpp
+++ b/gcodeworkshop/src/documentmanager.cpp
@@ -141,7 +141,7 @@ DocumentStyle::Ptr DocumentManager::documentStyle(const QString& type) const
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::documentStyle() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::documentStyle() : The" << type << "type is not registered." ;
 		return DocumentStyle::Ptr(new DocumentStyle());
 	}
 
@@ -159,7 +159,7 @@ void DocumentManager::setDocumentStyle(const DocumentStyle::Ptr& style)
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::setDocumentStyle() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::setDocumentStyle() : The" << type << "type is not registered." ;
 		return;
 	}
 
@@ -171,7 +171,7 @@ DocumentWidgetProperties::Ptr DocumentManager::documentWidgetProperties(const QS
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::documentWidgetProperties() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::documentWidgetProperties() : The" << type << "type is not registered." ;
 		return DocumentWidgetProperties::Ptr(new DocumentWidgetProperties());
 	}
 
@@ -189,7 +189,7 @@ void DocumentManager::setDocumentWidgetProperties(const DocumentWidgetProperties
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::setDocumentWidgetProperties() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::setDocumentWidgetProperties() : The" << type << "type is not registered." ;
 		return;
 	}
 
@@ -201,7 +201,7 @@ void DocumentManager::updateDocuments(const QString& type)
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::updateDocuments() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::updateDocuments() : The" << type << "type is not registered." ;
 		return;
 	}
 
@@ -217,7 +217,7 @@ Document* DocumentManager::createDocument(const QString& type, const QString& id
 	DocumentProducer* producer = documentProducer(type);
 
 	if (!producer) {
-		qWarning() << "DocumentManager::createDocument() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::createDocument() : The" << type << "type is not registered." ;
 		return nullptr;
 	}
 
@@ -239,7 +239,7 @@ DocumentInfo::Ptr DocumentManager::createDocumentInfo(const QString& type)
 	if (producer) {
 		info = producer->createDocumentInfo();
 	} else {
-		qWarning() << "DocumentManager::createDocumentInfo() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::createDocumentInfo() : The" << type << "type is not registered." ;
 	}
 
 	return DocumentInfo::Ptr(info);
@@ -253,7 +253,7 @@ DocumentStyle::Ptr DocumentManager::createDocumentStyle(const QString& type)
 	if (producer) {
 		style = producer->createDocumentStyle();
 	} else {
-		qWarning() << "DocumentManager::createDocumentStyle() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::createDocumentStyle() : The" << type << "type is not registered." ;
 	}
 
 	return DocumentStyle::Ptr(style);
@@ -267,7 +267,7 @@ DocumentWidgetProperties::Ptr DocumentManager::createDocumentWidgetProperties(co
 	if (producer) {
 		properties = producer->createDocumentWidgetProperties();
 	} else {
-		qWarning() << "DocumentManager::createDocumentWidgetProperties() : The" << type << "type is not registred." ;
+		qWarning() << "DocumentManager::createDocumentWidgetProperties() : The" << type << "type is not registered." ;
 	}
 
 	return DocumentWidgetProperties::Ptr(properties);
@@ -328,7 +328,7 @@ void DocumentManager::registerDocumentProducer(DocumentProducer* producer)
 	const QString& type = producer->documentType();
 
 	if (m_producers.contains(type)) {
-		qWarning() << "DocumentManager::registerProducer() : The" << type << "type always registred." ;
+		qWarning() << "DocumentManager::registerProducer() : The" << type << "type always registered." ;
 		return;
 	}
 

--- a/gcodeworkshop/src/gcodeworkshop.cpp
+++ b/gcodeworkshop/src/gcodeworkshop.cpp
@@ -507,7 +507,7 @@ bool GCodeWorkShop::save(Document* doc, bool forceSaveAs)
 		}
 
 		if (QFileInfo(oldFileName).suffix() == "") {
-			// sometimes when file has no extension QFileDialog::getSaveFileName will no apply choosen filter (extension)
+			// sometimes when file has no extension QFileDialog::getSaveFileName will not apply chosen filter (extension)
 			oldFileName.append(".nc");
 		}
 
@@ -1687,8 +1687,8 @@ void GCodeWorkShop::createActions()
 	closeAllAct->setToolTip(tr("Close all the windows"));
 	connect(closeAllAct, SIGNAL(triggered()), this, SLOT(closeAllMdiWindows()));
 
-	tileHAct = new QAction(QIcon(":/images/tile_h.png"), tr("Tile &horyzontally"), this);
-	tileHAct->setToolTip(tr("Tile the windows horyzontally"));
+	tileHAct = new QAction(QIcon(":/images/tile_h.png"), tr("Tile &horizontally"), this);
+	tileHAct->setToolTip(tr("Tile the windows horizontally"));
 	connect(tileHAct, SIGNAL(triggered()), ui->mdiArea, SLOT(tileSubWindows()));
 
 	tileVAct = new QAction(QIcon(":/images/tile_v.png"), tr("Tile &vertycally"), this);
@@ -2319,7 +2319,7 @@ void GCodeWorkShop::createFindToolBar()
 		findEdit->setToolTip(
 		    tr("<b>Letter$$</b> - matches any number.<p><b>Letter$max$min</b> - matches number &lt;=max &gt;=min.</p>"
 		       \
-		       "<p><b>$min</b> can be ommited, then equal 0</p>" \
+		       "<p><b>$min</b> can be omitted, then equal 0</p>" \
 		       "<p><b>X$100$-10</b> - matches all X with value -10 to 100</p>"));
 		CapsLockEventFilter* findEditEventFilter = new CapsLockEventFilter(findEdit);
 		connect(this, SIGNAL(intCapsLockChanged(bool)), findEditEventFilter, SLOT(setCapsLockEnable(bool)));
@@ -3333,7 +3333,7 @@ void GCodeWorkShop::updateSessionMenus(const QStringList& sessionList)
 {
 	sessionsMenu->clear();
 
-	// TODO memory leack?
+	// TODO memory leak?
 	QActionGroup* actionGroup = new QActionGroup(sessionsMenu);
 	actionGroup->setExclusive(true);
 

--- a/gcodeworkshop/src/inlinecalc.cpp
+++ b/gcodeworkshop/src/inlinecalc.cpp
@@ -47,7 +47,7 @@ InLineCalc::InLineCalc(QWidget* parent) : QLineEdit(parent)
 	           "ABS(x)\n" +
 	           "TRUNC(x)\n" +
 	           "PI\n" +
-	           tr("Press Enter to accept or click anywere to canacel"));
+	           tr("Press Enter to accept or click anywhere to cancel"));
 
 	connect(this, SIGNAL(editingFinished()), this, SLOT(done()));
 

--- a/gcodeworkshop/src/setupdialog.ui
+++ b/gcodeworkshop/src/setupdialog.ui
@@ -270,7 +270,7 @@
          <item row="4" column="1">
           <widget class="QPushButton" name="backgroundColorButton">
            <property name="text">
-            <string>Backgroud</string>
+            <string>Background</string>
            </property>
            <property name="flat">
             <bool>true</bool>
@@ -309,10 +309,10 @@
        <item row="4" column="2">
         <widget class="QPushButton" name="curLineColorButton">
          <property name="toolTip">
-          <string>Highlighed current line color</string>
+          <string>Highlighted current line color</string>
          </property>
          <property name="text">
-          <string>Hi&amp;ghlighed current line color</string>
+          <string>Hi&amp;ghlighted current line color</string>
          </property>
          <property name="autoDefault">
           <bool>false</bool>
@@ -512,7 +512,7 @@
           <item row="0" column="0">
            <widget class="QCheckBox" name="ui_showAllCodecs">
             <property name="text">
-             <string>Show all avalaible codecs</string>
+             <string>Show all available codecs</string>
             </property>
            </widget>
           </item>

--- a/gcodeworkshop/src/tooltips.h
+++ b/gcodeworkshop/src/tooltips.h
@@ -268,7 +268,7 @@ QString writeTooltipFile()
 	settings.setValue("G97", _TR("<b>G97 S</b>xx - constant spindle speed xx"));
 
 	settings.setValue("NCYL",
-	                  _TR("<b>NCYL</b> - if specified in fixed cycle, positioning to the definied hole position is performed, but the cycle axis does not operate"));
+	                  _TR("<b>NCYL</b> - if specified in fixed cycle, positioning to the defined hole position is performed, but the cycle axis does not operate"));
 	settings.setValue("NOEX",
 	                  _TR("<b>NOEX</b> - if specified in fixed cycle, no axis movements may be performed"));
 
@@ -294,10 +294,10 @@ QString writeTooltipFile()
 	                  _TR("<b>DFUP[</b>val<b>]</b> - unit integer implementation (raising)"));
 	settings.setValue("MOD", _TR("<b>MOD[</b>val<b>,</b>yy<b>]</b> - remainder of val/yy"));
 
-	settings.setValue("VDIN", _TR("<b>VDIN[</b>xx<b>]</b> - imput variable no. xx"));
+	settings.setValue("VDIN", _TR("<b>VDIN[</b>xx<b>]</b> - input variable no. xx"));
 	settings.setValue("VDOUT", _TR("<b>VDOUT[</b>xx<b>]</b> - output variable no. xx"));
 	settings.setValue("VUACM",
-	                  _TR("<b>VUACM[</b>n<b>]='</b>text<b>'</b> - sub message for user definied alarms, n - subscript expression, text - max. 16 chracters"));
+	                  _TR("<b>VUACM[</b>n<b>]='</b>text<b>'</b> - sub message for user defined alarms, n - subscript expression, text - max. 16 characters"));
 
 	settings.setValue("MODIN",
 	                  _TR("<b>MODIN O</b>nnnn [<b>Q</b>]xx - subprogram call after axis movement, nnnn - prog. name, xx - number of repetitions"));
@@ -320,10 +320,10 @@ QString writeTooltipFile()
 
 	settings.setValue("EQ", _TR("<b>EQ</b> - equal to"));
 	settings.setValue("NE", _TR("<b>NE</b> - not equal to"));
-	settings.setValue("GT", _TR("<b>GT</b> - greather than"));
+	settings.setValue("GT", _TR("<b>GT</b> - greater than"));
 	settings.setValue("LE", _TR("<b>LE</b> - less than or equal to"));
 	settings.setValue("LT", _TR("<b>LT</b> - less than"));
-	settings.setValue("GE", _TR("<b>GE</b> - greather than or equal to"));
+	settings.setValue("GE", _TR("<b>GE</b> - greater than or equal to"));
 	settings.setValue("IF",
 	                  _TR("<b>IF[</b>condition<b>] N</b>xxxx - if condition is true goto block xxxx"));
 
@@ -480,16 +480,16 @@ QString writeTooltipFile()
 
 	settings.setValue("EQ", _TR("<b>EQ</b> - equal to"));
 	settings.setValue("NE", _TR("<b>NE</b> - not equal to"));
-	settings.setValue("GT", _TR("<b>GT</b> - greather than"));
+	settings.setValue("GT", _TR("<b>GT</b> - greater than"));
 	settings.setValue("LE", _TR("<b>LE</b> - less than or equal to"));
 	settings.setValue("LT", _TR("<b>LT</b> - less than"));
-	settings.setValue("GE", _TR("<b>GE</b> - greather than or equal to"));
+	settings.setValue("GE", _TR("<b>GE</b> - greater than or equal to"));
 	settings.setValue("IF",
 	                  _TR("<b>IF[</b>condition<b>]</b>do something - if condition is true do something"));
 	settings.setValue("GOTO", _TR("<b>GOTO</b>nnnn - jump to block nnnn"));
 
 	settings.setValue("WHILE",
-	                  _TR("<b>WHILE[</b>condition<b>] DO</b>n <br />...<br />commands<br />... <br /><b>END</b>n  - loop - while condition true do commands beetwen DOn and ENDn"));
+	                  _TR("<b>WHILE[</b>condition<b>] DO</b>n <br />...<br />commands<br />... <br /><b>END</b>n  - loop - while condition true do commands between DOn and ENDn"));
 	settings.setValue("END", _TR("<b>END</b>n - end of WHILE DOn loop"));
 
 	settings.setValue("EOR", _TR("<b>EOR</b> - exclusive OR"));
@@ -572,9 +572,9 @@ QString writeTooltipFile()
 	settings.setValue("@124",
 	                  _TR("<b>@124 R</b>|<b>K</b>yy <b>R</b>|<b>K</b>xx <b>K</b>nnnn - if yy is less than xx jump to nnnn"));
 	settings.setValue("@125",
-	                  _TR("<b>@125 R</b>|<b>K</b>yy <b>R</b>|<b>K</b>xx <b>K</b>nnnn - if yy is greather than or equal to xx jump to nnnn"));
+	                  _TR("<b>@125 R</b>|<b>K</b>yy <b>R</b>|<b>K</b>xx <b>K</b>nnnn - if yy is greater than or equal to xx jump to nnnn"));
 	settings.setValue("@126",
-	                  _TR("<b>@126 R</b>|<b>K</b>yy <b>R</b>|<b>K</b>xx <b>K</b>nnnn - if yy is greather than xx jump to nnnn"));
+	                  _TR("<b>@126 R</b>|<b>K</b>yy <b>R</b>|<b>K</b>xx <b>K</b>nnnn - if yy is greater than xx jump to nnnn"));
 
 	settings.setValue("@620", _TR("<b>@620 R</b>xx - increment value in param. xx"));
 	settings.setValue("@621", _TR("<b>@621 R</b>xx - decrement value in param. xx"));

--- a/install/build-helper.sh
+++ b/install/build-helper.sh
@@ -44,10 +44,10 @@ Options:
               By default this is <bld_dir>/<pkg_name>_<pkg_version>
   -q qmake    The name or full path of the qmake utility. In some
               distributives, qmake for Qt 6 is named qmake6.
-  -s suffux   The suffix that will be added to the package name after the
+  -s suffix   The suffix that will be added to the package name after the
               version and before the architecture type.
               Nothing is added by default.
-  -v version  Define the package version. By default version gettings from
+  -v version  Define the package version. By default version settings from
               the version.h file.
   -w browser  Define the webengine to be used. Possible values:
               WebEngine or WebKit (default).


### PR DESCRIPTION
Found via `codespell -q 3 -D ../dictionary.txt -S "./lang,./3rdparty" -L adrress,childs,diamon,doubleclick,evalute,highligh,hight,inout,roate,speedin`